### PR TITLE
GI type 2 conversion rework

### DIFF
--- a/ranger_tools/common.py
+++ b/ranger_tools/common.py
@@ -58,7 +58,8 @@ def clamp(v, lt, gt):
     return v
 
 
-def rgb16_to_rgb24(rgb16: bytes) -> tuple:
+def rgb565le_to_rgb888(rgb16: bytes) -> tuple:
+    # Unpack from little endian 2 bytes
     r =  rgb16[1] & 0b11111000
     g = (rgb16[0] & 0b11100000) >> 5 | (rgb16[1] & 0b00000111) << 3
     b =  rgb16[0] & 0b00011111
@@ -67,6 +68,7 @@ def rgb16_to_rgb24(rgb16: bytes) -> tuple:
     b <<= 3
 
     return (r, g, b)
+
 
 def rgb24_to_rgb16(rgb24: tuple) -> bytes:
     r, g, b = rgb24
@@ -83,7 +85,7 @@ def rgb24_to_rgb16(rgb24: tuple) -> bytes:
     return bytes([b, a])
 
 
-def rgba8888_to_rgb565le(rgba32: tuple) -> bytes:
+def rgb888_to_rgb565le(rgba32: tuple) -> bytes:
     r, g, b, a = rgba32
 
     if a == 0:

--- a/ranger_tools/common.py
+++ b/ranger_tools/common.py
@@ -85,34 +85,13 @@ def rgb24_to_rgb16(rgb24: tuple) -> bytes:
     return bytes([b, a])
 
 
-def rgb888_to_rgb565le(rgba32: tuple) -> bytes:
-    r, g, b, a = rgba32
+def rgb888_to_rgb565le(r, g, b) -> bytes:
+    # Essentially reducing green channel bit depth to 5 after reduction for white balance
+    g &= 0b11111011
 
-    if a == 0:
-        return bytes([0, 0])
+    r = r >> 3 << 11
+    g = g >> 2 << 5
+    b = b >> 3
 
-    else:
-        if a == 255:
-            # Essentially reducing green channel bit depth to 5 for white balance
-            g &= 0b11111011
-
-        else:
-            # Preventing format from "exploding" color channel values when combined with transparency channel
-            if r > a:
-                r = max(r - (255 - a), a)
-
-            if g > a:
-                g = max(g - (255 - a), a)
-
-            if b > a:
-                b = max(b - (255 - a), a)
-
-            # Essentially reducing green channel bit depth for white balance
-            g -= g & 0b00000111
-
-        r = r >> 3 << 11
-        g = g >> 2 << 5
-        b = b >> 3
-
-    # Swap to little endian
+    # Pack into little endian 2 bytes
     return bytes([g & 0b11100000 | b, (r | g) >> 8])

--- a/ranger_tools/graphics/gi.py
+++ b/ranger_tools/graphics/gi.py
@@ -615,7 +615,7 @@ def to_image_2(gi: GI) -> Image:
                     else:
                         a = (63 - buf.read_byte()) << 2
 
-						r, g, b, _ = result.getpixel((pos.x + layer.start_X - header.start_X, pos.y + layer.start_Y - header.start_Y))
+                        r, g, b, _ = result.getpixel((pos.x + layer.start_X - header.start_X, pos.y + layer.start_Y - header.start_Y))
 
                         if a not in (0, 255):
                             # Retrieveing second layer pixel value from premultiplied alpha (desctructive operation)

--- a/ranger_tools/graphics/gi.py
+++ b/ranger_tools/graphics/gi.py
@@ -2,11 +2,10 @@ from PIL import Image
 import time
 
 from ..io import Buffer
-from ..common import rgb16_to_rgb24, rgb24_to_rgb16, Point, rgba8888_to_rgb565le
+from ..common import rgb565le_to_rgb888, rgb24_to_rgb16, Point, rgb888_to_rgb565le
 
-__all__ = [
-    'GI',
-]
+__all__ = ['GI']
+
 
 class Layer:
     def __init__(self):
@@ -373,7 +372,7 @@ def from_image_2(img: Image, fmt, opt=None) -> GI:
                     pixels = b''
                 cnt += 1
 
-                pixels += rgba8888_to_rgb565le(data[index])
+                pixels += rgb888_to_rgb565le(data[index])
 
                 if cnt >= 127:
                     buf0.write_byte(0x80 + cnt) # read cnt pixels + pixels
@@ -428,7 +427,7 @@ def from_image_2(img: Image, fmt, opt=None) -> GI:
                     pixels2 = b''
                 cnt += 1
 
-                pixels1 += rgba8888_to_rgb565le(data[index])
+                pixels1 += rgb888_to_rgb565le(data[index])
                 pixels2 += bytes([(255 - data[index][3]) >> 2])
 
                 if cnt >= 127:
@@ -553,8 +552,7 @@ def to_image_0(gi: GI) -> Image:
         for y in range(layer.start_Y, layer.finish_Y):
             for x in range(layer.start_X, layer.finish_X):
                 rgb16 = buf.read(2)
-                img.putpixel((x - header.start_X, y - header.start_Y), rgb16_to_rgb24(rgb16))
-
+                img.putpixel((x - header.start_X, y - header.start_Y), rgb565le_to_rgb888(rgb16))
 
     else:
         raise ValueError(f'Invalid bitmask: {(header.r_bitmask, header.g_bitmask, header.b_bitmask)}')
@@ -610,7 +608,7 @@ def to_image_2(gi: GI) -> Image:
 
                 while cnt:
                     if li in (0, 1):
-                        r, g, b = rgb16_to_rgb24(buf.read(2))
+                        r, g, b = rgb565le_to_rgb888(buf.read(2))
                         res = (r, g, b, 255)
                     else:
                         r, g, b, _ = result.getpixel((pos.x + layer.start_X - header.start_X, pos.y + layer.start_Y - header.start_Y))

--- a/ranger_tools/graphics/gi.py
+++ b/ranger_tools/graphics/gi.py
@@ -427,7 +427,7 @@ def from_image_2(img: Image, fmt, opt=None) -> GI:
                     pixels2 = b''
                 cnt += 1
 
-                # Premultiplying pixel by alpha for second layer (desctructive operation)
+                # Premultiplying pixel by alpha for second layer (destructive operation)
                 r = (data[index][0] * data[index][3]) >> 8
                 g = (data[index][1] * data[index][3]) >> 8
                 b = (data[index][2] * data[index][3]) >> 8
@@ -626,7 +626,7 @@ def to_image_2(gi: GI) -> Image:
                         b = out_data[index+2]
 
                         if a not in (0, 255):
-                            # Retrieveing second layer pixel value from premultiplied alpha (desctructive operation)
+                            # Retrieveing second layer pixel value from premultiplied alpha (destructive operation)
                             r = round((r / a) * 63) << 2
                             g = round((g / a) * 63) << 2
                             b = round((b / a) * 63) << 2


### PR DESCRIPTION
Parts of alpha blending rendering algorithm are processed onto the texture during saving to GI type 2 as optimization.
This commit adds said processing during conversion to type 2, as well as reverting this processing when converting from type 2.
Alas, this processing is destructive and permanently destroys some information, accumulating loss at each conversion cycle.

Alpha processing removed from pixel format conversion in common and moved to GI conversion code.

As a bonus, includes conversion optimization that approximately doubles speed of conversion by removing Image pixel operations from cycles.